### PR TITLE
uniqueString関数を使用する際は `var` で変数を定義する

### DIFF
--- a/prompts/main.txt
+++ b/prompts/main.txt
@@ -6,7 +6,8 @@
     As an engineer, generate a Bicep file and a parameters.json file based on the provided Quickstart page content.
     Ensure that the files can be deployed immediately without requiring the user to edit them.
 3. Avoiding Name Collisions:
-    Use unique values in parameter definitions to avoid issues such as name collisions. This can be achieved using constructs like `func-${uniqueString(resourceGroup().id)}`.
+    Use unique values in variable definitions to avoid issues such as name collisions. 
+    This can be achieved using constructs like `var functionAppName = 'func-${uniqueString(resourceGroup().id)}'`, not like `param functionAppName string = 'func-${uniqueString(resourceGroup().id)}'`.
 4. Reference:
     Refer to the successfully deployed files provided below for guidance.
 5. Deployment Command:


### PR DESCRIPTION
uniqueString関数を使用して変数を定義する際は、 `param` ではなく `var` を使用するように指示してみました。
名前の重複を避けるためにuniqueString関数を使用しても、paramで定義しているのはデフォルト値なのでparameters.jsonでハードコーディングされた値がユニークじゃなければ重複が起きるからです。